### PR TITLE
Feature/107 Filter invalid data fetched from API

### DIFF
--- a/src/lib/schemas/profile.ts
+++ b/src/lib/schemas/profile.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { Chains, Platforms, PlatformLinkCategories } from "lib/types";
+import { makeFilteredArraySchema } from "lib/schemas/utils";
 
 export const VerificationProofSchema = z.object({
   type: z.string(), // TODO: Enum?
@@ -43,9 +44,9 @@ export const FeaturedAssetSchema = z.object({
 
 export const ProfileDataSchema = z
   .object({
-    customLinks: z.array(CustomLinkSchema).optional(),
-    platformLinks: z.array(PlatformLinkSchema).optional(),
-    walletAddresses: z.array(WalletAddressSchema).optional(),
-    featuredAssets: z.array(FeaturedAssetSchema).optional(),
+    customLinks: makeFilteredArraySchema(CustomLinkSchema).optional(),
+    platformLinks: makeFilteredArraySchema(PlatformLinkSchema).optional(),
+    walletAddresses: makeFilteredArraySchema(WalletAddressSchema).optional(),
+    featuredAssets: makeFilteredArraySchema(FeaturedAssetSchema).optional(),
   })
   .passthrough();

--- a/src/lib/schemas/utils.ts
+++ b/src/lib/schemas/utils.ts
@@ -6,9 +6,11 @@ import { ZodSchema, z } from "zod";
  * @param schema A Z schema instance
  * @returns A Zod array schema of the given schema
  */
-export const makeFilteredArraySchema = <S extends ZodSchema>(schema: S) =>
+export const makeFilteredArraySchema = <TSchema extends ZodSchema>(
+  schema: TSchema
+) =>
   z.array(z.unknown()).transform((items) =>
-    items?.filter((item): item is z.infer<S> => {
+    items?.filter((item): item is z.infer<TSchema> => {
       const result = schema.safeParse(item);
       if (!result.success) {
         // TODO: Report the validation error

--- a/src/lib/schemas/utils.ts
+++ b/src/lib/schemas/utils.ts
@@ -1,0 +1,19 @@
+import { ZodSchema, z } from "zod";
+
+/**
+ * Creates a Zod array schema of a given schema, which filters out invalid items
+ *
+ * @param schema A Z schema instance
+ * @returns A Zod array schema of the given schema
+ */
+export const makeFilteredArraySchema = <S extends ZodSchema>(schema: S) =>
+  z.array(z.unknown()).transform((items) =>
+    items?.filter((item): item is z.infer<S> => {
+      const result = schema.safeParse(item);
+      if (!result.success) {
+        // TODO: Report the validation error
+        // result.error doesn't leak any data, so it's safe to report
+      }
+      return result.success;
+    })
+  );

--- a/src/lib/schemas/walletprovider.ts
+++ b/src/lib/schemas/walletprovider.ts
@@ -1,5 +1,6 @@
 import { Chains } from "lib/types";
 import { z } from "zod";
+import { makeFilteredArraySchema } from "lib/schemas/utils";
 
 export const NftMetadataAttributeSchema = z
   .object({
@@ -20,7 +21,7 @@ export const NftMetadataSchema = z
     external_link: z.string().nullable(),
     image: z.string().nullable(),
     background_color: z.string().nullish(),
-    attributes: z.array(NftMetadataAttributeSchema).optional(),
+    attributes: makeFilteredArraySchema(NftMetadataAttributeSchema).optional(),
   })
   .passthrough();
 
@@ -40,7 +41,7 @@ export const NftTokenSchema = z
 export const NftListApiResponseSchema = z
   .object({
     status: z.enum(["success", "error"]),
-    data: z.array(NftTokenSchema).nullable(),
+    data: makeFilteredArraySchema(NftTokenSchema).nullable(),
     error: z.string().nullish(),
   })
   .passthrough();

--- a/src/lib/utils/profileUtils.ts
+++ b/src/lib/utils/profileUtils.ts
@@ -88,6 +88,7 @@ export const getProfileData = async (
     VERIDA_ONE_PUBLIC_PROFILE_RECORD_ID,
     {}
   )) as ProfileData;
+
   return ProfileDataSchema.parse(profileRecord);
   // TODO: Try catch errors and identify the type of error to handle it specifically
   // For the moment, there is no specific handling of the errors, so there is no point of catching and identifying them.


### PR DESCRIPTION
When the application fetches data externally, the data is validated against a given schema.

When there was one single mistake in the data (for instance in one item in an array), the whole data thrown out and not used.

Now, arrays are validated item by item and invalid ones are filtered out, so that we can still use the valid ones.